### PR TITLE
Build: Add automated test rules to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,57 +2,45 @@
 #   CONFIGURAÇÕES DO PROJETO
 # =============================
 
-# Compilador
 CC = gcc
 
 # Flags de compilação
 # -Wall: mostra warnings básicos
 # -Wextra: mostra warnings adicionais
 # -Iinclude: adiciona o diretório include/ ao caminho de headers
-CFLAGS = -Wall -Wextra -Iinclude
+# -Itests: permite incluir unity.h e headers dos testes
+CFLAGS = -Wall -Wextra -Iinclude -Itests
 
 # Diretórios principais
-SRC_DIR   = src
-BUILD_DIR = build
+SRC_DIR      = src
+BUILD_DIR    = build
+TEST_DIR     = tests
+TEST_BUILD   = $(BUILD_DIR)/tests
 
-# Lista todos os .c dentro de src/
+# Arquivos do jogo
 SRC = $(wildcard $(SRC_DIR)/*.c)
-
-# Converte: src/nome.c → build/nome.o
 OBJ = $(SRC:$(SRC_DIR)/%.c=$(BUILD_DIR)/%.o)
-
-# Nome do executável final (Linux NÃO usa .exe)
-TARGET = $(BUILD_DIR)/pacman
+TARGET = $(BUILD_DIR)/pacman   # Linux NÃO usa .exe
 
 
 # =============================
 #   REGRAS PRINCIPAIS
 # =============================
 
-# Regra padrão que será executada ao rodar "make"
+# Regra padrão executada com "make"
 all: $(TARGET)
 
 
 # =============================
-#   COMPILAÇÃO DOS ARQUIVOS .c
+#   COMPILAÇÃO DO JOGO
 # =============================
 
-# Regra genérica:
-# Cada arquivo .c vira um .o dentro de build/
-#
-#   $< é o arquivo de entrada   (src/arquivo.c)
-#   $@ é o arquivo de saída     (build/arquivo.o)
-#
+# Cada arquivo .c vira build/arquivo.o
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c
 	mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
-
-# =============================
-#      LINKAGEM FINAL
-# =============================
-
-# Une todos os .o e gera o executável final
+# Linka e cria o executável final do jogo
 $(TARGET): $(OBJ)
 	$(CC) $(OBJ) -o $(TARGET)
 
@@ -66,8 +54,46 @@ run: $(TARGET)
 
 
 # =============================
+#   COMPILAÇÃO DOS TESTES
+# =============================
+
+# Todos os arquivos test_*.c dentro de tests/
+TEST_FILES = $(wildcard $(TEST_DIR)/test_*.c)
+
+# Converte tests/test_X.c → build/tests/test_X
+TEST_BINARIES = $(TEST_FILES:$(TEST_DIR)/%.c=$(TEST_BUILD)/%)
+
+# Regras de compilação dos testes unitários
+# Cada teste precisa:
+#   - test_X.c
+#   - unity.c
+#   - objetos do jogo (mapa.o, pecman.o, etc.)
+#
+$(TEST_BUILD)/test_%: $(TEST_DIR)/test_%.c $(TEST_DIR)/unity.c $(OBJ)
+	mkdir -p $(TEST_BUILD)
+	$(CC) $(CFLAGS) $^ -o $@
+
+
+# Compila todos os testes
+compila-tests: $(TEST_BINARIES)
+	@echo "✓ Todos os testes foram compilados na pasta build/tests/"
+
+
+# Executa todos os testes
+test: tests
+	@echo "====== EXECUTANDO TESTES ======"
+	@for t in $(TEST_BINARIES); do \
+		echo "--> $$t"; \
+		./$$t || exit 1; \
+		echo ""; \
+	done
+	@echo "✓ Todos os testes passaram com sucesso!"
+
+
+# =============================
 #   LIMPAR ARQUIVOS GERADOS
 # =============================
 
 clean:
 	rm -rf $(BUILD_DIR)/*.o $(TARGET)
+	rm -rf $(TEST_BUILD)


### PR DESCRIPTION
This pull request introduces a complete test automation workflow to the project, enabling the compilation and execution of all unit tests located in the `tests/` directory. The implementation improves the project structure, standardizes the build process, and prepares the repository for future CI/CD integration.

---

## 🚀 Summary of Changes

### ✔️ 1. Added rule to compile all unit tests (`make compila-tests`)
A new Makefile rule `compila-tests` was created to:

- Detect all files matching the pattern `tests/test_*.c`
- Automatically compile each test into a corresponding binary
- Generate test executables inside a dedicated directory:  

```
build/tests/
```

This prevents test binaries from mixing with the main game build.

---

### ✔️ 2. Added support for Unity Test Framework
The Makefile now includes:

- `tests/unity.c`
- `tests/unity.h`

These files are automatically included in the compilation of every test.

Each test now compiles by linking:
- The Unity framework  
- All project source files from `src/`  
- The test file itself  

Ensuring full compatibility between tests and the game's logic.

---

### ✔️ 3. Created directory structure automatically
If the directory `build/tests/` does not exist, the Makefile now creates it at build time.  
This ensures the workflow works smoothly in a clean environment or fresh clone.

---

### ✔️ 4. Rule to execute all tests (`make test`)
A new rule `test` was added to:

- Iterate over all executables inside `build/tests/`
- Execute each one sequentially
- Print clear, readable console output for each test result

This allows developers to run the entire test suite with a single command:

```sh
make test
```

This closes #19 
