### PR TITLE
ci: enable workflow dispatch button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by enabling manual workflow runs through the GitHub UI. This is accomplished by adding the `workflow_dispatch` trigger to the `.github/workflows/ci.yml` file.

This closes #22