### PR TITLE
fix: add clean screen functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode

--- a/include/mapa.h
+++ b/include/mapa.h
@@ -24,6 +24,7 @@ typedef struct posicao POSICAO;
 void liberamapa();
 void lemapa();
 void alocamapa();
+void limpatela();
 void imprimemapa();
 int encontraheroi(POSICAO* p, MAPA* m, char c);
 int podeandarnomapa(MAPA* m, int x, int y, char personagem);

--- a/src/mapa.c
+++ b/src/mapa.c
@@ -112,6 +112,10 @@ void alocamapa(MAPA* m){
     }
 }
 
+void limpatela() {
+    printf("\033[2J\033[3J\033[H");
+}
+
 void imprimemapa(MAPA* m){
     for (int i=0; i < m->linhas; i++){
         printf("%s", m->matriz[i]);

--- a/src/pecman.c
+++ b/src/pecman.c
@@ -124,6 +124,7 @@ int main() {
     encontraheroi(&heroi, &m, HEROI);
 
     do {
+        limpatela();
         imprimemapa(&m);                      // função para imprimir o mapa no loop
 
         char direcao;                       // char que vai armazenar a mudança de direção do herói

--- a/tests/test_imprimemapa.c
+++ b/tests/test_imprimemapa.c
@@ -24,6 +24,7 @@ void tearDown() {
 }
 
 void test_imprimemapa_nao_crasha() {
+    limpatela();
     imprimemapa(&m8);
     TEST_PASS();
 }


### PR DESCRIPTION
This pull request introduces a new utility function for clearing the terminal screen and integrates it into both the main game loop and relevant tests to improve the user interface experience.

**Terminal screen handling improvements:**

* Added a new function `limpatela()` in `mapa.c` that clears the terminal screen using ANSI escape codes, and declared it in the `mapa.h` header. [[1]](diffhunk://#diff-cb13fc127dbbe0d0c567255bd966645c32a3f0e03c66789454c2b14fc2123b41R115-R118) [[2]](diffhunk://#diff-3b98a61166f1fdfb70619a0457daaaf3e67facd13cfc64d17ced77a08fc36741R27)
* Updated the main game loop in `pecman.c` to call `limpatela()` before printing the map, ensuring the screen is cleared before each frame for a cleaner display.
* Modified the `test_imprimemapa_nao_crasha` test to call `limpatela()` before printing the map, ensuring consistency with the main application behavior.

This closes #25